### PR TITLE
add one rpc checkBalanceAgainstTx

### DIFF
--- a/mock/MockProvider.js
+++ b/mock/MockProvider.js
@@ -305,6 +305,14 @@ class MockProvider {
   cfx_getConfirmationRiskByHash() {
     return randomHex(64);
   }
+
+  cfx_checkBalanceAgainstTransaction() {
+    return {
+      willPayTxFee: true,
+      willPayCollateral: true,
+      isBalanceEnough: true,
+    };
+  }
 }
 
 module.exports = MockProvider;

--- a/src/Conflux.js
+++ b/src/Conflux.js
@@ -855,10 +855,17 @@ class Conflux {
 
   /**
    * Check whether balance is enough for an transaction
+   * 
+   * @param options {object} - See [format.againstTx](#util/format.js/againstTx)
+   * @return {Promise<object>} The gas used and storage occupied for the simulated call/transaction.
+   * - `bool` isBalanceEnough: is balance cover everything.
+   * - `bool` willPayCollateral: is balance cover collateral.
+   * - `bool` willPayTxFee: is balance cover tx fee.
+   * 
    */
   async checkBalanceAgainstTransaction({ ...options }) {
     options = await this.prepareTransaction(options);
-    const tx = format.sendTx(options);
+    const tx = format.againstTx(options);
     const result = await this.provider.call('cfx_checkBalanceAgainstTransaction',
       tx.from,
       tx.to,

--- a/src/util/format.js
+++ b/src/util/format.js
@@ -434,4 +434,13 @@ format.estimateTx = Parser({
   data: format.hex.or(undefined),
 });
 
+format.againstTx = Parser({
+  from: format.address,
+  to: format.address.or(null).or(undefined),
+  gasPrice: format.hexUInt,
+  gas: format.hexUInt,
+  storageLimit: format.hexUInt,
+  epochHeight: format.uInt.or(undefined),
+});
+
 module.exports = format;

--- a/test/conflux/conflux.after.test.js
+++ b/test/conflux/conflux.after.test.js
@@ -200,3 +200,16 @@ test('sendTransaction by address', async () => {
 
   await expect(promise.confirmed({ timeout: 0 })).rejects.toThrow('Timeout');
 });
+
+test('checkBalanceAgainstTransaction', async() => {
+  const balanceEnoughResponse = await cfx.checkBalanceAgainstTransaction({
+    from: ADDRESS,
+    nonce: 0,
+    gasPrice: 100,
+    gas: 21000,
+    chainId: 0,
+  });
+  expect(balanceEnoughResponse.willPayTxFee).toEqual(true);
+  expect(balanceEnoughResponse.willPayCollateral).toEqual(true);
+  expect(balanceEnoughResponse.isBalanceEnough).toEqual(true);
+});


### PR DESCRIPTION
Add one rpc method to Conflux, which can be used to check whether one account have enough balance for an transaction

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/js-conflux-sdk/74)
<!-- Reviewable:end -->
