### PR TITLE
add types declaration on the package.json field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "sdk"
   ],
   "main": "src/index.js",
+  "types": "./types/index.d.ts",
   "browser": "dist/js-conflux-sdk.umd.min.js",
   "browserify-browser": {
     "secp256k1": "secp256k1/elliptic"


### PR DESCRIPTION
add types declaration on the package.json field  to fix the type missing issue
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/js-conflux-sdk/81)
<!-- Reviewable:end -->
